### PR TITLE
Fixed npe on invalid token key

### DIFF
--- a/src/main/java/org/jahia/modules/apitokens/graphql/GqlPersonalApiTokensMutation.java
+++ b/src/main/java/org/jahia/modules/apitokens/graphql/GqlPersonalApiTokensMutation.java
@@ -109,6 +109,9 @@ public class GqlPersonalApiTokensMutation {
         try {
             return jcrTemplate.doExecute(jcrTemplate.getSessionFactory().getCurrentUser(), null, null, session -> {
                 TokenDetails details = tokensService.getTokenDetails(key, session);
+                if (details == null) {
+                    return false;
+                }
                 if (name != null) {
                     details.setName(name);
                 }


### PR DESCRIPTION
Just check that token exists and return false if it does not , instead of crashing