### PR TITLE
Changed docker image used for the tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ workflows:
           context: QA_ENVIRONMENT
           requires:
             - jahia-modules-orb/build
-          jahia_image: jahia/jahia-discovery-dev:8-SNAPSHOT
+          jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           tests_manifest: provisioning-manifest-build.yml
           module_id: << pipeline.parameters.MODULE_ID >> 
           testrail_project: << pipeline.parameters.TESTRAIL_PROJECTNAME >> 
@@ -240,12 +240,12 @@ workflows:
             - jahia-modules-orb/initialize
           matrix:
             parameters:            
-              jahia_image: ["jahia/jahia-discovery:8", "jahia/jahia-discovery-dev:8-SNAPSHOT"]
-              tests_manifest: ["provisioning-manifest-snapshot.yml"]
-              module_id: ["<< pipeline.parameters.MODULE_ID >>"]
-              testrail_project: ["<< pipeline.parameters.TESTRAIL_PROJECTNAME >>"]
-              testrail_milestone: ["<< matrix.jahia_image >>"]
-              should_skip_artifacts: [true]
-              should_skip_testrail: [false]
-              should_skip_notifications: [false]
-              should_skip_zencrepes: [false]
+              jahia_image: ["jahia/jahia-ee:8", "jahia/jahia-ee-dev:8-SNAPSHOT"]
+          tests_manifest: "provisioning-manifest-snapshot.yml"
+          module_id: "<< pipeline.parameters.MODULE_ID >>"
+          testrail_project: "<< pipeline.parameters.TESTRAIL_PROJECTNAME >>"
+          testrail_milestone: "<< matrix.jahia_image >>"
+          should_skip_artifacts: true
+          should_skip_testrail: false
+          should_skip_notifications: false
+          should_skip_zencrepes: false

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -1,2 +1,24 @@
-# Nothing to do
-- sleep: 100
+- installBundle: 
+  - 'mvn:org.jahia.modules/personal-api-tokens/1.0.0'
+  - 'mvn:org.jahia.modules/press/3.0.0'
+  - 'mvn:org.jahia.modules/person/3.1.0'
+  - 'mvn:org.jahia.modules/news/3.1.0'
+  - 'mvn:org.jahia.modules/font-awesome/6.1.3'
+  - 'mvn:org.jahia.modules/calendar/3.1.0'
+  - 'mvn:org.jahia.modules/bootstrap3-core/4.1.0'
+  - 'mvn:org.jahia.modules/bootstrap3-components/4.1.0'
+  - 'mvn:org.jahia.modules/location/3.0.0'
+  - 'mvn:org.jahia.modules/topstories/3.0.0'
+  - 'mvn:org.jahia.modules/rating/3.2.0'
+  - 'mvn:org.jahia.modules/event/3.0.0'
+  - 'mvn:org.jahia.modules/bookmarks/3.1.0'
+  - 'mvn:org.jahia.modules/dx-base-demo-core/2.2.0'
+  - 'mvn:org.jahia.modules/dx-base-demo-templates/3.1.0'
+  - 'mvn:org.jahia.modules/dx-base-demo-components/2.1.0'
+  - 'mvn:org.jahia.modules/digitall/2.0.0'
+  autoStart: true
+  uninstallPreviousVersion: true
+
+# Import the Digitall site
+- import: "jar:mvn:org.jahia.modules/digitall/2.0.0/zip/import!/users.zip"
+- importSite: "jar:mvn:org.jahia.modules/digitall/2.0.0/zip/import!/Digitall.zip"

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -1,5 +1,4 @@
 - installBundle: 
-  - 'mvn:org.jahia.modules/personal-api-tokens/1.0.0'
   - 'mvn:org.jahia.modules/press/3.0.0'
   - 'mvn:org.jahia.modules/person/3.1.0'
   - 'mvn:org.jahia.modules/news/3.1.0'

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -1,3 +1,28 @@
+- installBundle: 
+  - 'mvn:org.jahia.modules/personal-api-tokens/1.0.0'
+  - 'mvn:org.jahia.modules/press/3.0.0'
+  - 'mvn:org.jahia.modules/person/3.1.0'
+  - 'mvn:org.jahia.modules/news/3.1.0'
+  - 'mvn:org.jahia.modules/font-awesome/6.1.3'
+  - 'mvn:org.jahia.modules/calendar/3.1.0'
+  - 'mvn:org.jahia.modules/bootstrap3-core/4.1.0'
+  - 'mvn:org.jahia.modules/bootstrap3-components/4.1.0'
+  - 'mvn:org.jahia.modules/location/3.0.0'
+  - 'mvn:org.jahia.modules/topstories/3.0.0'
+  - 'mvn:org.jahia.modules/rating/3.2.0'
+  - 'mvn:org.jahia.modules/event/3.0.0'
+  - 'mvn:org.jahia.modules/bookmarks/3.1.0'
+  - 'mvn:org.jahia.modules/dx-base-demo-core/2.2.0'
+  - 'mvn:org.jahia.modules/dx-base-demo-templates/3.1.0'
+  - 'mvn:org.jahia.modules/dx-base-demo-components/2.1.0'
+  - 'mvn:org.jahia.modules/digitall/2.0.0'
+  autoStart: true
+  uninstallPreviousVersion: true
+
+# Import the Digitall site
+- import: "jar:mvn:org.jahia.modules/digitall/2.0.0/zip/import!/users.zip"
+- importSite: "jar:mvn:org.jahia.modules/digitall/2.0.0/zip/import!/Digitall.zip"
+
 - installBundle: 'mvn:org.jahia.modules/personal-api-tokens'
   autoStart: true
   uninstallPreviousVersion: true

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -1,5 +1,4 @@
 - installBundle: 
-  - 'mvn:org.jahia.modules/personal-api-tokens/1.0.0'
   - 'mvn:org.jahia.modules/press/3.0.0'
   - 'mvn:org.jahia.modules/person/3.1.0'
   - 'mvn:org.jahia.modules/news/3.1.0'


### PR DESCRIPTION
Some of the automated tests are broken due to an issue with the discovery image license file (https://jira.jahia.org/browse/QA-13823).

Since there isn't a strong reason for sticking to the discovery image for PAT, moving the automated tests to use nightly instead.