### PR TITLE
Added graphql-dxm-provider to the manifest

### DIFF
--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -15,6 +15,7 @@
   - 'mvn:org.jahia.modules/dx-base-demo-templates/3.1.0'
   - 'mvn:org.jahia.modules/dx-base-demo-components/2.1.0'
   - 'mvn:org.jahia.modules/digitall/2.0.0'
+  - 'mvn:org.jahia.modules/graphql-dxm-provider'
   autoStart: true
   uninstallPreviousVersion: true
 

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -15,6 +15,7 @@
   - 'mvn:org.jahia.modules/dx-base-demo-templates/3.1.0'
   - 'mvn:org.jahia.modules/dx-base-demo-components/2.1.0'
   - 'mvn:org.jahia.modules/digitall/2.0.0'
+  - 'mvn:org.jahia.modules/graphql-dxm-provider'
   autoStart: true
   uninstallPreviousVersion: true
 


### PR DESCRIPTION
Otherwise the tests with the last released version of Jahia are going to fail.
