### PR TITLE
TECH-210: Remove jahia 8.0.x stable release integration test for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 # Avoid using project-specific variables in the jobs or steps.
 # Instead, declare those as pipeline parameters (At the top of the config file).
 # This eases portability of the config file across different modules
-parameters: 
+parameters:
   TESTS_MANIFEST: # Manifest to be executed by the test container when triggered from an API call
     type: string
     default: ""
@@ -22,7 +22,7 @@ parameters:
     default: "Personal API Tokens"
   TESTRAIL_MILESTONE:
     type: string
-    default: "Default"    
+    default: "Default"
   GITHUB_SLUG:
     type: string
     default: "jahia/personal-api-tokens"
@@ -49,14 +49,14 @@ parameters:
     default: false
   SHOULD_SKIP_ARTIFACTS:
     type: boolean
-    default: true    
+    default: true
   SHOULD_SKIP_TESTRAIL:
     type: boolean
     default: true
-  SHOULD_SKIP_NOTIFICATIONS: 
+  SHOULD_SKIP_NOTIFICATIONS:
     type: boolean
     default: true
-  SHOULD_SKIP_ZENCREPES: 
+  SHOULD_SKIP_ZENCREPES:
     type: boolean
     default: false
   UPDATE_SIGNATURE:
@@ -75,20 +75,20 @@ workflows:
         - << pipeline.parameters.IS_RELEASE >>
         - << pipeline.parameters.IS_ROLLBACK >>
         - << pipeline.parameters.UPDATE_SIGNATURE >>
-        - << pipeline.parameters.IS_MANUAL_TESTRUN >> 
+        - << pipeline.parameters.IS_MANUAL_TESTRUN >>
     jobs:
       - jahia-modules-orb/initialize
       - jahia-modules-orb/update-signature:
           context: QA_ENVIRONMENT
           requires:
-            - jahia-modules-orb/initialize        
+            - jahia-modules-orb/initialize
           pre-steps:
             - jahia-modules-orb/update-signature-prestep
           ssh_key_fingerprints:  << pipeline.parameters.SSH_KEY_FINGERPRINT >>
       - jahia-modules-orb/static-analysis:
           requires:
             - jahia-modules-orb/initialize
-          auditci_level: "high"   
+          auditci_level: "high"
       - jahia-modules-orb/build:
           context: QA_ENVIRONMENT
           requires:
@@ -98,7 +98,7 @@ workflows:
       - jahia-modules-orb/sonar-analysis:
           context: QA_ENVIRONMENT
           requires:
-            - jahia-modules-orb/build          
+            - jahia-modules-orb/build
           primary_release_branch: << pipeline.parameters.PRIMARY_RELEASE_BRANCH >>
           github_slug: << pipeline.parameters.GITHUB_SLUG >>
       - jahia-modules-orb/publish:
@@ -115,9 +115,9 @@ workflows:
             - jahia-modules-orb/build
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           tests_manifest: provisioning-manifest-build.yml
-          module_id: << pipeline.parameters.MODULE_ID >> 
-          testrail_project: << pipeline.parameters.TESTRAIL_PROJECTNAME >> 
-          testrail_milestone: << pipeline.parameters.TESTRAIL_MILESTONE >>          
+          module_id: << pipeline.parameters.MODULE_ID >>
+          testrail_project: << pipeline.parameters.TESTRAIL_PROJECTNAME >>
+          testrail_milestone: << pipeline.parameters.TESTRAIL_MILESTONE >>
 
   # The on-release workflow was created to handle the full release lifecycle after creating a release using GitHub
   # https://github.com/Jahia/sandbox/releases
@@ -166,7 +166,7 @@ workflows:
   # The on-rollback workflow was created to handle release rollback when a release has been deleted from Github
   # The rollback pipeline/job performs the following action:
   # - restore rollback artifact cache created from the release job
-  # - Run mvn:rollback 
+  # - Run mvn:rollback
   # - Delete github tag associated with the release
   on-rollback:
     when: << pipeline.parameters.IS_ROLLBACK >>
@@ -196,7 +196,7 @@ workflows:
     when: << pipeline.parameters.UPDATE_SIGNATURE >>
     jobs:
       - jahia-modules-orb/update-signature:
-          context: QA_ENVIRONMENT      
+          context: QA_ENVIRONMENT
           pre-steps:
             - jahia-modules-orb/update-signature-prestep
           ssh_key_fingerprints:  << pipeline.parameters.SSH_KEY_FINGERPRINT >>
@@ -212,8 +212,8 @@ workflows:
             - jahia-modules-orb/initialize
           jahia_image: << pipeline.parameters.JAHIA_IMAGE >>
           tests_manifest: << pipeline.parameters.TESTS_MANIFEST >>
-          module_id: << pipeline.parameters.MODULE_ID >> 
-          testrail_project: << pipeline.parameters.TESTRAIL_PROJECTNAME >> 
+          module_id: << pipeline.parameters.MODULE_ID >>
+          testrail_project: << pipeline.parameters.TESTRAIL_PROJECTNAME >>
           testrail_milestone: << pipeline.parameters.TESTRAIL_MILESTONE >>
           should_skip_artifacts: << pipeline.parameters.SHOULD_SKIP_ARTIFACTS >>
           should_skip_testrail: << pipeline.parameters.SHOULD_SKIP_TESTRAIL >>
@@ -239,8 +239,9 @@ workflows:
           requires:
             - jahia-modules-orb/initialize
           matrix:
-            parameters:            
-              jahia_image: ["jahia/jahia-ee:8", "jahia/jahia-ee-dev:8-SNAPSHOT"]
+            parameters:
+              # need to add stable image back after 8.1 release
+              jahia_image: ["jahia/jahia-ee-dev:8-SNAPSHOT"]
           tests_manifest: "provisioning-manifest-snapshot.yml"
           module_id: "<< pipeline.parameters.MODULE_ID >>"
           testrail_project: "<< pipeline.parameters.TESTRAIL_PROJECTNAME >>"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-210

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Remove stable release integration tests for now as it is failing because of new 8.1 requirement (which hasn't been released yet).

Need to add back once 8.1 has been released.
