### PR TITLE
TECH-970: Added staging-repository to maven settings

### DIFF
--- a/.github/maven.settings.xml
+++ b/.github/maven.settings.xml
@@ -28,5 +28,10 @@
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
+        <server>
+            <id>staging-repository</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>
     </servers>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <jahia-depends>default,userDashboard,graphql-dxm-provider</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
-        <jahia-module-signature>MC0CFH6ZH0xv8djgXBc8ejhPV52gIsv4AhUAlf1p6butzbB2HF7WTsRdz326sQ0=</jahia-module-signature>
+        <jahia-module-signature>MCwCFCjCBpkTQS8+iKeu28uzBl0wn++PAhQ1qEpkLqfIQV3+F0CBF83wnteGaw==</jahia-module-signature>
         <export-package>org.jahia.modules.apitokens</export-package>
         <import-package>
             graphql.annotations.annotationTypes;version="[7.2,9)",


### PR DESCRIPTION
This will fix this error:
```
Error: [ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.5.1:deploy (injected-nexus-deploy) on project personal-api-tokens: Server credentials with ID "staging-repository" not found! -> [Help 1]
```