### PR TITLE
feat: add permission for accessing the Administration >  "User api tokens" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For example it's possible to create a token by calling :
 mutation {
   admin {
     personalApiTokens {
-      createToken(userId:"root", name:"my token", expireAt:"2020-12-12")
+      createToken(name:"my-token", expireAt:"2025-12-12", scopes:["graphql"], state: ACTIVE)
     }
   }
 }
@@ -111,13 +111,18 @@ And to get its data with :
 query {
   admin {
     personalApiTokens {
-     token(token:"aJC9l44cSKGv4Xvb0Qc8o/V1Say1s77k0Q046/VIwo8=") {
-       key
-       name
-       user {
-         name
-       }
-     }
+     tokens {
+        edges {
+          node {
+            createdAt
+            expireAt
+            key
+            name
+            state
+            updatedAt
+          }
+        }
+      }
     }
   }
 }

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -3,4 +3,7 @@
     <developerTools jcr:primaryType="jnt:permission">
         <personal-api-tokens jcr:primaryType="jnt:permission"/>
     </developerTools>
+    <admin jcr:primaryType="jnt:permission">
+        <admin-personal-api-tokens jcr:primaryType="jnt:permission"/>
+    </admin>
 </permissions>

--- a/src/main/java/org/jahia/modules/apitokens/graphql/GqlPersonalApiTokensMutation.java
+++ b/src/main/java/org/jahia/modules/apitokens/graphql/GqlPersonalApiTokensMutation.java
@@ -20,7 +20,6 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
 import org.apache.commons.lang.StringUtils;
-import org.jahia.api.usermanager.JahiaUserManagerService;
 import org.jahia.modules.apitokens.TokenDetails;
 import org.jahia.modules.apitokens.TokenService;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
@@ -51,24 +50,19 @@ public class GqlPersonalApiTokensMutation {
     @GraphQLOsgiService
     private JCRTemplate jcrTemplate;
 
-    @Inject
-    @GraphQLOsgiService
-    private JahiaUserManagerService userManagerService;
-
     /**
      * Create a new token
      *
      * @param name     Name to give to the token
-     * @param site     The site the user belongs to, null if global user
+     * @param scopes   Scopes attached to this token
      * @param expireAt Expiration date of the token
      * @param state    State to give the newly created token
      * @return new token
      */
     @GraphQLField
-    @GraphQLDescription("Create a new token")
+    @GraphQLDescription("Create a new token for connected user")
     @GraphQLRequiresPermission("personal-api-tokens")
     public String createToken(@GraphQLName("name") @GraphQLDescription("Name to give to the token") @GraphQLNonNull String name,
-                              @GraphQLName("site") @GraphQLDescription("The site the user belongs to, null if global user") String site,
                               @GraphQLName("expireAt") @GraphQLDescription("Expiration date of the token") String expireAt,
                               @GraphQLName("scopes") @GraphQLDescription("Scopes attached to this token") List<String> scopes,
                               @GraphQLName("state") @GraphQLDescription("State to give the newly created token") TokenState state) {

--- a/src/main/javascript/PersonalApiTokens.register.jsx
+++ b/src/main/javascript/PersonalApiTokens.register.jsx
@@ -19,6 +19,7 @@ export default function () {
         targets: ['administration-server-usersAndRoles:45'],
         label: 'personal-api-tokens:adminTitle',
         isSelectable: true,
+        requiredPermission: 'admin-personal-api-tokens',
         render: () => <UserApiTokens/>
     });
 }

--- a/tests/cypress/fixtures/createRoles.graphql
+++ b/tests/cypress/fixtures/createRoles.graphql
@@ -21,11 +21,56 @@ mutation {
             ]) {
                 uuid
             }
-        }
-        m2: mutateNode(pathOrId: "/j:acl/GRANT_g_users") {
+        },
+        m2: mutateNode(pathOrId: "/roles") {
+            addChild(name: "admin-token", primaryNodeType: "jnt:role", properties: [
+                {
+                    name: "j:nodeTypes"
+                    values: "rep:root"
+                },
+                {
+                    name: "j:permissionNames"
+                    values: ["administrationAccess", "adminUsers", "admin-personal-api-tokens"]
+                },
+                {
+                    name: "j:privilegedAccess"
+                    value: "true"
+                },
+                {
+                    name: "j:roleGroup"
+                    value: "server-role"
+                }
+            ]) {
+                uuid
+            }
+        },
+        m3: mutateNode(pathOrId: "/roles") {
+            addChild(name: "admin-no-token", primaryNodeType: "jnt:role", properties: [
+                {
+                    name: "j:nodeTypes"
+                    values: "rep:root"
+                },
+                {
+                    name: "j:permissionNames"
+                    values: ["administrationAccess", "adminUsers"]
+                },
+                {
+                    name: "j:privilegedAccess"
+                    value: "true"
+                },
+                {
+                    name: "j:roleGroup"
+                    value: "server-role"
+                }
+            ]) {
+                uuid
+            }
+        },
+        m4: mutateNode(pathOrId: "/j:acl/GRANT_g_users") {
             mutateProperty(name: "j:roles") {
                 addValue(value: "token")
             }
         }
+
     }
 }

--- a/tests/cypress/fixtures/createToken.graphql
+++ b/tests/cypress/fixtures/createToken.graphql
@@ -1,7 +1,7 @@
-mutation($tokenName: String!, $siteKey: String, $expireAt: String, $tokenState: TokenState) {
+mutation($tokenName: String!, $expireAt: String, $tokenState: TokenState) {
     admin {
         personalApiTokens {
-            createToken(name: $tokenName, site: $siteKey, expireAt: $expireAt, state: $tokenState)
+            createToken(name: $tokenName, expireAt: $expireAt, state: $tokenState)
         }
     }
 }

--- a/tests/cypress/fixtures/deleteRoles.graphql
+++ b/tests/cypress/fixtures/deleteRoles.graphql
@@ -1,7 +1,9 @@
 mutation {
     jcr {
         deleteNode(pathOrId: "/roles/token")
-        m2: mutateNode(pathOrId: "/j:acl/GRANT_g_users") {
+        m2: deleteNode(pathOrId: "/roles/admin-token")
+        m3: deleteNode(pathOrId: "/roles/admin-no-token")
+        m4: mutateNode(pathOrId: "/j:acl/GRANT_g_users") {
             mutateProperty(name: "j:roles") {
                 removeValue(value: "token")
             }

--- a/tests/cypress/fixtures/getApiUser copy.graphql
+++ b/tests/cypress/fixtures/getApiUser copy.graphql
@@ -1,5 +1,0 @@
-query {
-  currentUser {
-    name
-  }
-}

--- a/tests/cypress/integration/api/createToken.spec.ts
+++ b/tests/cypress/integration/api/createToken.spec.ts
@@ -51,7 +51,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
             mutation: GQL_CREATE,
             variables: {
                 tokenName: name,
-                siteKey: null,
                 expireAt: null,
                 tokenState: null,
             },
@@ -83,7 +82,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
             mutation: GQL_CREATE,
             variables: {
                 tokenName: name,
-                siteKey: null,
                 expireAt: null,
                 tokenState: 'DISABLED',
             },
@@ -117,7 +115,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
                 mutation: GQL_CREATE,
                 variables: {
                     tokenName: name,
-                    siteKey: null,
                     expireAt: null,
                     tokenState: 'INACTIVE', // This state does not exist
                 },
@@ -146,7 +143,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
             mutation: GQL_CREATE,
             variables: {
                 tokenName: name,
-                siteKey: null,
                 expireAt: expireAt,
                 tokenState: null,
             },
@@ -180,7 +176,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
             mutation: GQL_CREATE,
             variables: {
                 tokenName: name,
-                siteKey: null,
                 expireAt: expireAt,
                 tokenState: null,
             },
@@ -214,7 +209,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
                 mutation: GQL_CREATE,
                 variables: {
                     tokenName: name,
-                    siteKey: null,
                     expireAt: expireAt,
                     tokenState: null,
                 },
@@ -246,7 +240,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
                 mutation: GQL_CREATE,
                 variables: {
                     tokenName: name,
-                    siteKey: null,
                     expireAt: expireAt,
                     tokenState: null,
                 },
@@ -275,7 +268,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
             mutation: GQL_CREATE,
             variables: {
                 tokenName: name,
-                siteKey: null,
                 expireAt: expireAt,
                 tokenState: null,
             },
@@ -299,7 +291,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
                 mutation: GQL_CREATE,
                 variables: {
                     tokenName: name,
-                    siteKey: null,
                     expireAt: expireAt,
                     tokenState: null,
                 },
@@ -328,7 +319,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
                 mutation: GQL_CREATE,
                 variables: {
                     tokenName: name,
-                    siteKey: null,
                     expireAt: null,
                     tokenState: null,
                 },
@@ -354,7 +344,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
                 mutation: GQL_CREATE,
                 variables: {
                     tokenName: name,
-                    siteKey: null,
                     expireAt: null,
                     tokenState: null,
                 },
@@ -376,7 +365,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
                 mutation: GQL_CREATE,
                 variables: {
                     tokenName: name,
-                    siteKey: null,
                     expireAt: null,
                     tokenState: null,
                 },
@@ -404,7 +392,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
                 mutation: GQL_CREATE,
                 variables: {
                     tokenName: name,
-                    siteKey: null,
                     expireAt: null,
                     tokenState: null,
                 },
@@ -432,7 +419,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
             mutation: GQL_CREATE,
             variables: {
                 tokenName: name,
-                siteKey: null,
                 expireAt: null,
                 tokenState: null,
             },
@@ -460,7 +446,6 @@ describe('Token creation via API - mutation.admin.personalApiTokens.createToken'
             mutation: GQL_CREATE,
             variables: {
                 tokenName: name,
-                siteKey: null,
                 expireAt: null,
                 tokenState: null,
             },

--- a/tests/cypress/integration/myTokensE2E.spec.ts
+++ b/tests/cypress/integration/myTokensE2E.spec.ts
@@ -4,8 +4,6 @@ import { apollo } from '../support/apollo'
 import { deleteToken, getTokens, verifyToken } from '../support/gql'
 import { setupRoles } from './setupRoles'
 
-const PARAGRAPH_ELEMENT = 'p'
-
 const TEST_TOKEN_NAME = 'test-token'
 let TEST_TOKEN = ''
 

--- a/tests/cypress/integration/setupRoles.ts
+++ b/tests/cypress/integration/setupRoles.ts
@@ -1,6 +1,6 @@
 import { apollo } from '../support/apollo'
 
-export function setupRoles() {
+export function setupRoles(): void {
     before('create role', async function () {
         await apollo(Cypress.config().baseUrl, {
             username: 'root',

--- a/tests/cypress/integration/userTokensAccess.spec.ts
+++ b/tests/cypress/integration/userTokensAccess.spec.ts
@@ -1,4 +1,3 @@
-import { loginPage } from '../page-object/login.page'
 import { createUser, deleteUser, grantRoles } from '@jahia/cypress'
 import { setupRoles } from './setupRoles'
 

--- a/tests/cypress/integration/userTokensAccess.spec.ts
+++ b/tests/cypress/integration/userTokensAccess.spec.ts
@@ -1,0 +1,35 @@
+import { loginPage } from '../page-object/login.page'
+import { createUser, deleteUser, grantRoles } from '@jahia/cypress'
+import { setupRoles } from './setupRoles'
+
+describe('UI permission test - Access to the User API Tokens section in Administration', () => {
+    setupRoles()
+
+    before(function () {
+        createUser('penny', 'penny1234')
+        createUser('leonard', 'leonard1234')
+        grantRoles('/', ['admin-token'], 'penny', 'USER')
+        grantRoles('/', ['admin-no-token'], 'leonard', 'USER')
+    })
+
+    after(function () {
+        deleteUser('penny')
+        deleteUser('leonard')
+    })
+
+    it('Check access to admin users token page is possible (penny)', function () {
+        cy.login('penny', 'penny1234')
+        cy.visit(Cypress.config().baseUrl + '/jahia/administration/manageUsers', { failOnStatusCode: false })
+        cy.get("[data-sel-role*='manageUsers']").should('exist')
+        cy.get("[data-sel-role*='pat']").should('exist')
+        cy.logout()
+    })
+
+    it('Check access to admin users token page is not possible (leonard)', function () {
+        cy.login('leonard', 'leonard1234')
+        cy.visit(Cypress.config().baseUrl + '/jahia/administration/manageUsers', { failOnStatusCode: false })
+        cy.get("[data-sel-role*='manageUsers']").should('exist')
+        cy.get("[data-sel-role*='pat']").should('not.exist')
+        cy.logout()
+    })
+})

--- a/tests/cypress/page-object/personalTokens.page.ts
+++ b/tests/cypress/page-object/personalTokens.page.ts
@@ -32,6 +32,11 @@ class PersonalTokensPage extends BasePage {
         cy.get(this.elements.tokenNameInput).type(this.TEST_TOKEN_NAME)
     }
 
+    validatePageIsNotAccessible() {
+        cy.visit('/jahia/dashboard', { failOnStatusCode: false })
+        cy.get(this.elements.personalTokens).should('not.exist')
+    }
+
     validateTokenIsVisibleInTheTable() {
         tokensPage.getByText('p', this.TEST_TOKEN_NAME).should(this.BE_VISIBLE)
     }

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -15,7 +15,21 @@
 /**
  * @type {Cypress.PluginConfig}
  */
- module.exports = (on, config) => {
+module.exports = (on, config) => {
     require('@jahia/cypress/dist/plugins/registerPlugins').registerPlugins(on, config)
+
+    require('cypress-terminal-report/src/installLogsPrinter')(on, {
+        printLogsToConsole: 'onFail',
+        printLogsToFile: 'always',
+        outputRoot: config.projectRoot + '/results/',
+        // Used to trim the base path of specs and reduce nesting in the generated output directory.
+        specRoot: 'cypress/e2e',
+        outputTarget: {
+            'cypress-logs|txt': 'txt'
+        },
+        defaultTrimLength: 50000,
+        commandTrimLength: 5000,
+        routeTrimLength: 5000
+    });
     return config;
 };

--- a/tests/env.run.sh
+++ b/tests/env.run.sh
@@ -59,9 +59,9 @@ echo "$(date +'%d %B %Y - %k:%M') == Groovy script submitted =="
 done
 cd ..
 
-echo "$(date +'%d %B %Y - %k:%M')== Sleeping for an additional 120 seconds =="
+echo "$(date +'%d %B %Y - %k:%M')== Sleeping for an additional 30 seconds =="
 sleep 30
-echo "$(date +'%d %B %Y - %k:%M')== DONE - Sleeping for an additional 120 seconds =="
+echo "$(date +'%d %B %Y - %k:%M')== DONE - Sleeping for an additional 30 seconds =="
 
 echo "$(date +'%d %B %Y - %k:%M') == Fetching the list of installed modules =="
 ~/node_modules/@jahia/jahia-reporter/bin/run utils:modules \

--- a/tests/lib-tsconfig.json
+++ b/tests/lib-tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "rootDir": "./cypress",
+    "outDir": "./dist",
+    "module": "commonjs",
+    "declaration": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": [
+      "cypress",
+      "node",
+      "@jahia/cypress",
+      "@4tw/cypress-drag-drop",
+      "cypress-iframe",
+      "cypress-real-events",
+      "cypress-wait-until"
+    ]
+  },
+  "include": [
+    "./cypress/page-object/**/*"
+  ],
+   "exclude": [ "node_modules" ]
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -52,6 +52,7 @@
     "e2e:coverage": "yarn instrument && yarn cypress run --config integrationFolder=./instrumented/integration && yarn nyc report --reporter=html --report-dir=./results/coverage && yarn nyc report",
     "e2e:ci": "cypress run",
     "e2e:debug": "cypress open",
+    "build": "tsc -p ./lib-tsconfig.json",
     "lint": "eslint . -c .eslintrc.json --ext .ts"
   },
   "nyc": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,6 +7,8 @@
     "@cypress/code-coverage": "^3.9.5",
     "@cypress/webpack-preprocessor": "^5.4.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@jahia/jahia-reporter": "^1.0.30",
+    "@jahia/cypress": "^5.2.0",
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "babel-plugin-istanbul": "^6.0.0",
@@ -26,7 +28,6 @@
     "he": "^1.2.0",
     "husky": "^4.2.5",
     "istanbul-lib-coverage": "^3.0.0",
-    "@jahia/jahia-reporter": "^1.0.30",
     "lint-staged": "^10.2.11",
     "mocha-junit-reporter": "^2.0.0",
     "ms": "^2.1.2",
@@ -39,11 +40,12 @@
     "typescript": "^4.0.5",
     "util": "^0.12.3",
     "webpack": "4.46.0",
-    "yarn": "^1.22.4"
+    "yarn": "^1.22.22"
   },
   "resolutions": {
     "*/**/elliptic": "6.5.4",
-    "glob-parent": "^5.1.2"
+    "glob-parent": "^5.1.2",
+    "loader-utils": "^2.0.3"
   },
   "scripts": {
     "instrument": "nyc instrument --compact=false cypress instrumented",
@@ -79,11 +81,5 @@
   "bugs": {
     "url": "https://github.com/Jahia/personal-api-tokens/issues"
   },
-  "homepage": "https://github.com/Jahia/personal-api-tokens#readme",
-  "dependencies": {
-    "@jahia/cypress": "^1.1.3"
-  },
-  "resolutions": {
-    "loader-utils": "^2.0.3"
-  }
+  "homepage": "https://github.com/Jahia/personal-api-tokens#readme"
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -915,13 +915,13 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@jahia/cypress@^1.1.3":
-  version "1.1.4"
-  resolved "https://npm.jahia.com/@jahia%2fcypress/-/cypress-1.1.4.tgz#68ea119ebf91b2597e7977e9881e53e283ea1d31"
-  integrity sha512-kYQeAZUS5FpYw4fPsKOSJfEoWyv22QThDxbjWlFXU3H0e4sTWdDBILYVfB7uueEwcDwECRFO7DtyrDpCuNA4jw==
+"@jahia/cypress@^5.2.0":
+  version "5.2.0"
+  resolved "https://npm.jahia.com/@jahia%2fcypress/-/cypress-5.2.0.tgz#69cb8c8b13fdb97e918df8423f5ad1cf728405b9"
+  integrity sha512-0OeM0U7UBbKS2noMGUw5kCFIN0yhgOHL0iAWLGE9Nst2btNuChoVUQq1lIVDFNSopEgCM+gm8vdSsEhOidybgw==
   dependencies:
     "@apollo/client" "^3.4.9"
-    cypress-terminal-report "^3.4.2"
+    cypress-real-events "^1.11.0"
     graphql "^15.5.0"
     graphql-tag "^2.11.0"
 
@@ -2798,6 +2798,11 @@ cypress-multi-reporters@^1.4.0:
     debug "^4.1.1"
     lodash "^4.17.15"
 
+cypress-real-events@^1.11.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.14.0.tgz#c5495db50a2bd247f4accde983af7153566945d3"
+  integrity sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==
+
 cypress-terminal-report@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/cypress-terminal-report/-/cypress-terminal-report-3.0.3.tgz#6eeaaa93e7153cbcb443f3fb99124018bcf58cf0"
@@ -2806,17 +2811,6 @@ cypress-terminal-report@^3.0.3:
     chalk "^3.0.0"
     fs-extra "^9.0.1"
     methods "^1.1.2"
-    tv4 "^1.3.0"
-
-cypress-terminal-report@^3.4.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/cypress-terminal-report/-/cypress-terminal-report-3.5.2.tgz#fa4fbc6eca78d4f3db0a3dfc441fd1b98dcc110f"
-  integrity sha512-06y4xTOnztyUOIwk3B+YoAYrK5DSwgCMZhUieUdU3EDXjIb4BgRs/wqPYbfCrH/N5/Yb9aV2hjO95pjzEClwqQ==
-  dependencies:
-    chalk "^3.0.0"
-    fs-extra "^9.0.1"
-    methods "^1.1.2"
-    semver "^7.3.5"
     tv4 "^1.3.0"
 
 cypress@8:
@@ -4761,13 +4755,6 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
-
 json5@^2.1.0, json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
@@ -4942,14 +4929,14 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.2.3:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+loader-utils@^1.2.3, loader-utils@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
-    json5 "^1.0.1"
+    json5 "^2.1.2"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -5218,7 +5205,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -6390,13 +6377,6 @@ semver@^7.2.1, semver@^7.3.2:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.3.5:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -7605,10 +7585,10 @@ yargs@^15.0.2:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yarn@^1.22.4:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
+yarn@^1.22.22:
+  version "1.22.22"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz#ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  integrity sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
Add a dedicated permission to control access the Administration user personal access token section.
Update Academy accordingly.

Documentation for GraphQL mutation and query updated (readme).

Unused parameter in the token generation can lead to bad usage. Token generation is for connected user only so the site parameter is not used and not necessary.