### PR TITLE
docs: explain urlpatterns configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Personal API Tokens
 - [Build](#build)
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Configuration](#configuration)
   - [Token generation](#token-generation)
   - [GraphQL API](#graphql-api)
-  - [Configuration](#configuration)
 - [E2E tests](#e2e-tests)
 - [Links](#links)
 
@@ -79,6 +79,10 @@ Use `mvn install` to build the module.
 Deploy the module in your Jahia instance.
 
 ## Usage
+
+### Configuration
+
+For detailed information on how to configure URL patterns for token authentication, see the [Usage Documentation](docs/USAGE.md#configuration).
 
 ### Token generation
 
@@ -131,48 +135,6 @@ query {
   }
 }
 ```
-
-### Configuration
-
-#### URL Patterns Configuration
-
-You can configure which URL patterns are covered by token authentication by creating a configuration file. This allows you to protect specific API endpoints with token verification.
-
-##### Creating a Configuration File
-
-Create a configuration file in your module at:
-```
-META-INF/configurations/org.jahia.modules.PersonalApiToken-<config-name>.cfg
-```
-
-Replace `<config-name>` with a unique identifier for your configuration (e.g., `default`, `custom-api`, etc.).
-
-##### Configuration Format
-
-The configuration file should contain:
-
-```properties
-urlPatterns=/modules/myApi/*,/modules/anotherApi/*
-```
-
-**Properties:**
-- `urlPatterns`: Comma-separated list of URL patterns where token authentication will be verified
-  - Example: `/modules/api/*,/modules/myapi/*`
-  - Supports wildcards (`*`) for pattern matching
-
-##### Example Configuration
-
-**File:** `org.jahia.modules.PersonalApiToken-custom.cfg`
-```properties
-# Custom API configuration
-urlPatterns=/modules/myapi/*,/modules/endpoint/apiA,/modules/endpoint/apiB
-```
-
-##### Notes
-
-- Multiple configuration files can be created to define different URL pattern sets
-- Changes to configuration files are automatically detected and applied
-- The module provides a default configuration that protects `/modules/api/*` and `/modules/graphql`
 
 ## E2E tests
 


### PR DESCRIPTION
### Description
This pull request updates the documentation for the Personal API Tokens module to clarify and expand on how to configure URL patterns for token authentication. The changes introduce detailed instructions for creating and managing configuration files that specify which API endpoints are protected by personal API tokens.

**Documentation improvements:**

* Added a new "Configuration" section to both `README.md` and `docs/USAGE.md` with step-by-step instructions for setting up URL pattern configurations for token authentication, including the file location, format, and examples. 
* Updated the table of contents in `README.md` to include links to the new "Token generation," "GraphQL API," and "Configuration" sections for easier navigation.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
